### PR TITLE
Removed gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,6 +1,0 @@
-[user]
-	name = Marco Aceti
-	email = personale@marcoaceti.it
-	signingkey = 97EC65FCF63B73DA
-[commit]
-    gpgsign = true


### PR DESCRIPTION
Git-config parameters like user.* should not appear in local (repo) .gitconfig